### PR TITLE
Allow configuration of db credential file and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prediction model evaluation dashboard
 
-## To run locally
+## Quick Start
 
 1. Install requirements: `pip3 install -r requirements.txt`
 
@@ -11,3 +11,9 @@
 3. Run `python3 run_webapp.py`
 
 4. Enter `http://localhost:5001/` in your local browser
+
+## Running multiple instances
+Since Tyra is built to look at different project databases, being able to run multiple instances side-by-side is helpful. To accomplish this, you can pass environment variables to configure the database credential file path and the port. So these two commands will work:
+
+`PROFILE=/path/to/first/profile.yaml PORT=5001 python3 run_webapp.py`
+`PROFILE=/path/to/second/profile.yaml PORT=5002 python3 run_webapp.py`

--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+import os
+import yaml
+
+profile_file = os.environ.get('PROFILE', 'default_profile.yaml')
+
+with open(profile_file) as f:
+    config = yaml.load(f)

--- a/run_webapp.py
+++ b/run_webapp.py
@@ -1,2 +1,8 @@
 from webapp import app
-app.run(debug=True, host='localhost', port=5001)
+import os
+port = os.environ.get('PORT', 5001)
+try:
+    port = int(port)
+    app.run(debug=True, host='localhost', port=port)
+except ValueError as e:
+    print('Tyra not started: {}'.format(e))

--- a/webapp/query.py
+++ b/webapp/query.py
@@ -3,18 +3,16 @@ from sqlalchemy import create_engine
 import yaml
 from webapp import app
 import os
+from config import config
 
-with open('default_profile.yaml') as f:
-    config = yaml.load(f)
-
-config = {
+dbconfig = {
     'host':config['PGHOST'],
     'user':config['PGUSER'],
     'database':config['PGDATABASE'],
     'password':config['PGPASSWORD'],
     'port':config['PGPORT'],
 }
-dbengine = create_engine('postgres://', connect_args=config)
+dbengine = create_engine('postgres://', connect_args=dbconfig)
 
 
 def get_best_models(timestamp, metric, parameter=None, number=25):


### PR DESCRIPTION
- Inspect PORT environment variable in run_webapp, and use if present
- Introduce config module that inspects PROFILE environment variable and uses it to load db credentials if present
-  Modify query.py to use new config module
- Update README with information about running multiple instances