### PR TITLE
Hound config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+python:
+    enabled: true
+jshint:
+    ignore_file: .jshintignore

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+webapp/static/js/


### PR DESCRIPTION
Basic hound config. It looks like it does [jshint](https://github.com/jshint/jshint) by default, but I set it to ignore the directory where we paste external js code.