### PR TITLE
Modify model search to respect model groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ before_install:
 - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
 install:
 - pip install -r requirements.txt
-script: py.test -vvv -s --cov=webapp
+script: py.test -vvv -s -x --cov=webapp
 after_success: codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python: 3.4
-env:
-- TOXENV=py34
 before_install:
 - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
-script: tox -e ${TOXENV}
+install:
+- pip install -r requirements.txt
+script: py.test -vvv -s --cov=webapp
 after_success: codecov

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Tyra is designed to work on different data science projects, but to accomplish t
 - model_id - integer
 - run_time - timestamp
 - model_type - string
+- model_group_id - integer
+- test - boolean
+- config - JSON (can contain many things, but only test_end_date is used for now)
+
+### model_groups
+- model_group_id - integer
 
 ### evaluations
 - model_id - integer

--- a/frontend/components/model-table/component.js
+++ b/frontend/components/model-table/component.js
@@ -5,7 +5,7 @@ import ReactTable from 'react-table'
 
 export default React.createClass({
   getInitialState: function() {
-    return { data: [], loading: false }
+    return { data: [], loading: false, asOfDate: null }
   },
   componentDidMount: function() {
     this.search()
@@ -38,6 +38,7 @@ export default React.createClass({
       success: function(result) {
         self.setState({
           data: result.results,
+          asOfDate: result.as_of_date,
           loading: false
         })
       }
@@ -104,13 +105,17 @@ export default React.createClass({
       )
     } else {
       return (
-        <ReactTable
-          tableClassName="table"
-          columns={this.columns()}
-          data={this.state.data}
-          loadingComponent={function() { return null }}
-          showPageSizeOptions={false}
-          pageSize={15} />
+        <div>
+          <div>Models run after {this.props.startDate.format('YYYY-MM-DD')}</div>
+          <div>Metrics shown reflect performance when predicting results as of {this.state.asOfDate}. This is not necessarily indicative of model stability.</div>
+          <ReactTable
+            tableClassName="table"
+            columns={this.columns()}
+            data={this.state.data}
+            loadingComponent={function() { return null }}
+            showPageSizeOptions={false}
+            pageSize={15} />
+        </div>
       )
     }
   }

--- a/frontend/components/model-table/component.js
+++ b/frontend/components/model-table/component.js
@@ -55,7 +55,7 @@ export default React.createClass({
     }
   },
   standardColumnRenderer: function(columnName, props) {
-    return (<span>{props.row[columnName]}</span>)
+    return (<span>{Math.round(props.row[columnName] * 100) / 100}</span>)
   },
   handleModelIdClick: function(modelId) {
     const self = this

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 SQLAlchemy==1.0.14
 pandas==0.18.0
 PyYAML==3.11
-psycopg2==2.4.5
+psycopg2==2.5
 testing.postgresql
 pytest==2.9.2
 numpy

--- a/sample_json/evaluations/search_models.json
+++ b/sample_json/evaluations/search_models.json
@@ -1,6 +1,7 @@
 {
 	"results": [
-		{ "model_id": 1, "precision@10.0": 48.0, "recall@5.0": 45.0 },
-		{ "model_id": 3, "precision@10.0": 50.0, "recall@5.0": 60.0 }
-	]
+		{ "model_id": 2, "precision@10.0": 56.0, "recall@5.0": 55.0 },
+		{ "model_id": 10, "precision@10.0": 68.0, "recall@5.0": 65.0 }
+	],
+	"as_of_date": "2015-04-01"
 }

--- a/tests/test_evaluations_searchmodels.py
+++ b/tests/test_evaluations_searchmodels.py
@@ -1,13 +1,43 @@
 from datetime import datetime, timedelta
 from tests.utils import load_json_example, rig_test_client
 import json
+from psycopg2.extras import Json
+import logging
 
 CUTOFF = datetime(2016, 5, 2)
+
+model_groups_data = [
+    # model_group_id
+    (1,),
+    (2,),
+    (3,),
+    (4,),
+]
+
 models_data = [
-    # model_id, run_time, model_type
-    (1, CUTOFF + timedelta(days=1), 'a_model_type'),
-    (2, CUTOFF - timedelta(days=1), 'a_model_type'),
-    (3, CUTOFF + timedelta(days=1), 'a_model_type'),
+    # model_id, run_time, model_type, model_group_id, testing, config
+
+    # test end date is picked from this model group, as it is more recently run than model group 3
+    # the middle model should be picked because it is the second most recent
+    (1, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, Json({ 'test_end_date': '2016-04-01' })),
+    (2, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, Json({ 'test_end_date': '2015-04-01' })),
+    (3, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, Json({ 'test_end_date': '2014-04-01' })),
+
+    # skip because runtime is before the cutoff
+    (4, CUTOFF - timedelta(days=3), 'a_model_type', 2, False, Json({ 'test_end_date': '2015-04-01' })),
+
+    # this is a good model group, and model 10 should be picked based on test_end_date
+    (9, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, Json({ 'test_end_date': '2016-04-01' })),
+    (10, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, Json({ 'test_end_date': '2015-04-01' })),
+    (11, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, Json({ 'test_end_date': '2014-04-01' })),
+
+    # skip because marked testing
+    (5, CUTOFF + timedelta(days=1), 'a_model_type', 4, True, Json({ 'test_end_date': '2015-04-01' })),
+
+    # the last three should be skipped because same model group as 1-3 but less recent runtimes
+    (6, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, Json({ 'test_end_date': '2016-04-01' })),
+    (7, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, Json({ 'test_end_date': '2015-04-01' })),
+    (8, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, Json({ 'test_end_date': '2014-04-01' })),
 ]
 
 evaluations_data = [
@@ -17,11 +47,22 @@ evaluations_data = [
     (1, 'precision@', '5.0', 47),
     (1, 'precision@', '10.0', 48),
     (2, 'recall@', '5.0', 55),
+    (2, 'precision@', '10.0', 56),
     (3, 'recall@', '5.0', 60),
     (3, 'precision@', '10.0', 50),
+    (4, 'precision@', '10.0', 48),
+    (5, 'recall@', '5.0', 45),
+    (5, 'recall@', '10.0', 46),
+    (5, 'precision@', '5.0', 47),
+    (5, 'precision@', '10.0', 48),
+    (10, 'recall@', '5.0', 65),
+    (10, 'recall@', '10.0', 66),
+    (10, 'precision@', '5.0', 67),
+    (10, 'precision@', '10.0', 68),
 ]
 
 data = {
+    'model_groups': model_groups_data,
     'models': models_data,
     'evaluations': evaluations_data
 }
@@ -43,4 +84,5 @@ def test_search_models():
         assert response.status_code == 200
         response_data = json.loads(response.get_data().decode('utf-8'))
         expected = load_json_example(route)
+        logging.warning(response_data)
         assert expected == response_data

--- a/tests/test_evaluations_searchmodels.py
+++ b/tests/test_evaluations_searchmodels.py
@@ -5,6 +5,9 @@ from psycopg2.extras import Json
 import logging
 
 CUTOFF = datetime(2016, 5, 2)
+TOO_NEW = Json({'test_end_date': '2016-04-01'})
+TOO_OLD = Json({'test_end_date': '2014-04-01'})
+JUST_RIGHT = Json({'test_end_date': '2015-04-01'})
 
 model_groups_data = [
     # model_group_id
@@ -17,27 +20,30 @@ model_groups_data = [
 models_data = [
     # model_id, run_time, model_type, model_group_id, testing, config
 
-    # test end date is picked from this model group, as it is more recently run than model group 3
+    # test end date is picked from this model group,
+    # as it is more recently run than model group 3
     # the middle model should be picked because it is the second most recent
-    (1, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, Json({ 'test_end_date': '2016-04-01' })),
-    (2, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, Json({ 'test_end_date': '2015-04-01' })),
-    (3, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, Json({ 'test_end_date': '2014-04-01' })),
+    (1, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, TOO_NEW),
+    (2, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, JUST_RIGHT),
+    (3, CUTOFF + timedelta(days=3), 'a_model_type', 1, False, TOO_OLD),
 
     # skip because runtime is before the cutoff
-    (4, CUTOFF - timedelta(days=3), 'a_model_type', 2, False, Json({ 'test_end_date': '2015-04-01' })),
+    (4, CUTOFF - timedelta(days=3), 'a_model_type', 2, False, JUST_RIGHT),
 
-    # this is a good model group, and model 10 should be picked based on test_end_date
-    (9, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, Json({ 'test_end_date': '2016-04-01' })),
-    (10, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, Json({ 'test_end_date': '2015-04-01' })),
-    (11, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, Json({ 'test_end_date': '2014-04-01' })),
+    # this is a good model group,
+    # and model 10 should be picked based on test_end_date
+    (9, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, TOO_NEW),
+    (10, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, JUST_RIGHT),
+    (11, CUTOFF + timedelta(days=1), 'a_model_type', 3, False, TOO_OLD),
 
     # skip because marked testing
-    (5, CUTOFF + timedelta(days=1), 'a_model_type', 4, True, Json({ 'test_end_date': '2015-04-01' })),
+    (5, CUTOFF + timedelta(days=1), 'a_model_type', 4, True, JUST_RIGHT),
 
-    # the last three should be skipped because same model group as 1-3 but less recent runtimes
-    (6, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, Json({ 'test_end_date': '2016-04-01' })),
-    (7, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, Json({ 'test_end_date': '2015-04-01' })),
-    (8, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, Json({ 'test_end_date': '2014-04-01' })),
+    # the last three should be skipped because same model group as 1-3
+    # but less recent runtimes
+    (6, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, TOO_NEW),
+    (7, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, JUST_RIGHT),
+    (8, CUTOFF + timedelta(days=2), 'a_model_type', 1, False, TOO_OLD),
 ]
 
 evaluations_data = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,15 +13,29 @@ def load_json_example(route):
 
 def setup_data(engine, data):
     engine.execute('create schema results')
+
+    engine.execute("""
+    create table results.model_groups (
+        model_group_id int
+    )""")
+    for row in data.get('model_groups', []):
+        engine.execute(
+            'insert into results.model_groups values (%s)',
+            row
+        )
+
     engine.execute("""
     create table results.models (
         model_id int,
         run_time timestamp,
-        model_type varchar
+        model_type varchar,
+        model_group_id int,
+        test bool,
+        config json
     )""")
     for model in data.get('models', []):
         engine.execute(
-            'insert into results.models values (%s, %s, %s)',
+            'insert into results.models values (%s, %s, %s, %s, %s, %s)',
             model
         )
 

--- a/webapp/controller.py
+++ b/webapp/controller.py
@@ -43,10 +43,10 @@ def search_models():
     query_arg['timestamp'] = f['timestamp']
     query_arg['metrics'] = flattened_query
 
-    output = query.get_models(query_arg)
+    output, test_end_date = query.get_models(query_arg)
     try:
         output = output.to_dict('records')
-        return jsonify(results=(output))
+        return jsonify(results=(output), as_of_date=test_end_date)
     except:
         print('there are some problems')
         return jsonify({"sorry": "Sorry, no results! Please try again."}), 500

--- a/webapp/query.py
+++ b/webapp/query.py
@@ -42,10 +42,10 @@ def get_models(query_arg):
         where run_time >= %(runtime)s and test = 'false'
         order by run_time desc limit 1
     )
-    select distinct(config->>'test_end_date')
+    select distinct(config->'test_end_date')
     from results.models
     join recent_prod_mg using (model_group_id)
-    order by config->>'test_end_date' desc limit 2
+    order by config->'test_end_date' desc limit 2
     """
     try:
         results = db.engine.execute(


### PR DESCRIPTION
- Update model search query to find a reasonable test_end_date and only show models and metrics as of that test_end_date, and ignore models marked 'test'
- Update model search controller to return chosen test_end_date
- Add message in model-table component telling user about the chosen date
- Update model API test to include cases that ensure new requirements around test_end_date and test flag are obeyed
- Update search_models.json to reflect new expectations
- Upgrade psycopg2 to 2.5 to improve Json column support
- Add pytest.ini to make standard 'py.test' command work
- Update README to reflect additional schema items