### PR TITLE
localhost -> 0.0.0.0

### DIFF
--- a/run_webapp.py
+++ b/run_webapp.py
@@ -3,6 +3,6 @@ import os
 port = os.environ.get('PORT', 5001)
 try:
     port = int(port)
-    app.run(debug=True, host='localhost', port=port)
+    app.run(debug=True, host='0.0.0.0', port=port)
 except ValueError as e:
     print('Tyra not started: {}'.format(e))


### PR DESCRIPTION
Reason:


> The web server running in your container is listening for connections on port 5000 of the loopback network interface (127.0.0.1). As such this web server will only respond to http requests originating from that container itself.
> 
> In order for the web server to accept connections originating from outside of the container you need to have it bind to the 0.0.0.0 IP address.
> 
> As you are using Flask, this can be easily achieved in your runserver.py file by using:

```
if __name__ == '__main__':
    app.run(host='0.0.0.0')
```
....

from https://stackoverflow.com/questions/26423984/unable-to-connect-to-flask-app-on-docker-from-host